### PR TITLE
[TRAD-18] Na rota de listar files, adicionar o filtro obrigatório de project id

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -55,7 +55,7 @@ func main() {
 
 	// router.GET("/:id", rPhrase.FindByID)
 	router.POST("/file", rFile.CreateFile)
-	router.GET("/file", rFile.GetAllFiles)
+	router.GET("/files/:projectId", rFile.GetAllFiles)
 	router.POST("/file/:id/signed-url", rFile.CreateSignedURL)
 
 	router.Run()

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -55,7 +55,7 @@ func main() {
 
 	// router.GET("/:id", rPhrase.FindByID)
 	router.POST("/file", rFile.CreateFile)
-	router.GET("/files/:projectId", rFile.GetAllFiles)
+	router.GET("/file/:projectId", rFile.GetAllFiles)
 	router.POST("/file/:id/signed-url", rFile.CreateSignedURL)
 
 	router.Run()

--- a/internal/core/services/contracts.go
+++ b/internal/core/services/contracts.go
@@ -9,6 +9,6 @@ import (
 type FileHandler interface {
 	CreateFile(ctx context.Context, file *domain.File) (domain.File, error)
 	SetUploadSuccessful(ctx context.Context, file *domain.File) error
-	GetFiles(ctx context.Context) ([]domain.File, error)
+	GetFiles(ctx context.Context, projectId string) ([]domain.File, error)
 	CreateSignedURL(ctx context.Context, file *domain.File) (string, error)
 }

--- a/internal/core/services/file.go
+++ b/internal/core/services/file.go
@@ -73,7 +73,21 @@ func (f File) findFile(ctx context.Context, id string) (domain.File, error) {
 	return file, nil
 }
 
+func (f File) findProject(ctx context.Context, projectId string) error {
+	_, err := f.repo.FindProject(ctx, projectId)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (f *File) GetFiles(ctx context.Context, projectId string) ([]domain.File, error) {
+	err := f.findProject(ctx, projectId)
+	if err != nil {
+		return nil, errors.New("projectId not found")
+	}
+
 	files, err := f.repo.GetFiles(ctx, projectId)
 	if err != nil {
 		return nil, err

--- a/internal/core/services/file.go
+++ b/internal/core/services/file.go
@@ -73,8 +73,8 @@ func (f File) findFile(ctx context.Context, id string) (domain.File, error) {
 	return file, nil
 }
 
-func (f *File) GetFiles(ctx context.Context) ([]domain.File, error) {
-	files, err := f.repo.GetFiles(ctx)
+func (f *File) GetFiles(ctx context.Context, projectId string) ([]domain.File, error) {
+	files, err := f.repo.GetFiles(ctx, projectId)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repository/contracts.go
+++ b/internal/repository/contracts.go
@@ -11,4 +11,5 @@ type FileRepository interface {
 	FindFile(ctx context.Context, id string) (domain.File, error)
 	SetUploadSuccessful(ctx context.Context, file *domain.File) error
 	GetFiles(ctx context.Context, projectId string) ([]domain.File, error)
+	FindProject(ctx context.Context, projectId string) (string, error)
 }

--- a/internal/repository/contracts.go
+++ b/internal/repository/contracts.go
@@ -10,5 +10,5 @@ type FileRepository interface {
 	CreateFile(ctx context.Context, file domain.File) error
 	FindFile(ctx context.Context, id string) (domain.File, error)
 	SetUploadSuccessful(ctx context.Context, file *domain.File) error
-	GetFiles(ctx context.Context) ([]domain.File, error)
+	GetFiles(ctx context.Context, projectId string) ([]domain.File, error)
 }

--- a/internal/repository/file.go
+++ b/internal/repository/file.go
@@ -37,10 +37,10 @@ func (d *File) CreateFile(ctx context.Context, file domain.File) error {
 	return err
 }
 
-func (d *File) GetFiles(ctx context.Context) ([]domain.File, error) {
+func (d *File) GetFiles(ctx context.Context, projectId string) ([]domain.File, error) {
 	var files []domain.File
 
-	allFiles, err := d.cli.QueryContext(ctx, "SELECT id, project_id, status FROM files") // tem que arrrumar esse filePath
+	allFiles, err := d.cli.QueryContext(ctx, "SELECT id, project_id, status FROM files WHERE project_id = $1", projectId) // tem que arrrumar esse filePath
 	if err != nil {
 		return nil, err
 	}

--- a/internal/rest/file.go
+++ b/internal/rest/file.go
@@ -58,7 +58,8 @@ func (f File) CreateFile(ctx *gin.Context) {
 }
 
 func (f File) GetAllFiles(ctx *gin.Context) {
-	files, err := f.in.File.GetFiles(ctx)
+	projectId := ctx.Param("projectId")
+	files, err := f.in.File.GetFiles(ctx, projectId)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{
 			"error": err.Error(),


### PR DESCRIPTION
Substitui a antiga rota `GET` `/file` que recuperava todos os arquivos do banco de dados pela rota `GET` `/files/:projectId` que permite recuperar todos os arquivos pertencentes a um determinado projeto.